### PR TITLE
Use JS to redirect http to https

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,17 @@
   <link rel="stylesheet/less" href="index.less" type="text/css">
   <link rel="icon" type="image/png" href="lib/bugzilla.png" />
 
+  <script type="text/javascript">
+    (function() {
+      // Github pages doesn't have a force-https pref, so this is the best we can do.
+      // Whilst this can still be MITMed, it increases the chance that people will
+      // bookmark and share the https URLs.
+      if (/.*\.github\.io/.test(window.location.host) && window.location.protocol == "http:") {
+        window.location.protocol = "https";
+      }
+    })();
+  </script>
+
   <script src="lib/less-1.1.3.min.js" type="text/javascript"></script>
   <script src="lib/jquery-1.6.4.min.js" type="text/javascript"></script>
   <script src="lib/jquery.ui.autocomplete.js"></script>


### PR DESCRIPTION
Github pages doesn't have a force-https pref, so this is the best we can do.
Whilst this can still be MITMed, it increases the chance that people will
bookmark and share the https URLs.