### PR TITLE
Remove client-side redirect now GitHub pages support enforcing HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,17 +9,6 @@
   <link rel="stylesheet/less" href="index.less" type="text/css">
   <link rel="icon" type="image/png" href="lib/bugzilla.png" />
 
-  <script type="text/javascript">
-    (function() {
-      // Github pages doesn't have a force-https pref, so this is the best we can do.
-      // Whilst this can still be MITMed, it increases the chance that people will
-      // bookmark and share the https URLs.
-      if (/.*\.github\.io/.test(window.location.host) && window.location.protocol == "http:") {
-        window.location.protocol = "https";
-      }
-    })();
-  </script>
-
   <script src="lib/less-2.5.1.min.js" type="text/javascript"></script>
   <script src="lib/jquery-1.6.4.min.js" type="text/javascript"></script>
   <script src="lib/jquery.ui.autocomplete.js"></script>


### PR DESCRIPTION
GitHub pages now support enforcing HTTPS, so the "awful but better than nothing" client-side redirect can now be removed:
https://help.github.com/articles/securing-your-github-pages-site-with-https/